### PR TITLE
fix: add --collector.systemd to allow for node_systemd_unit_state

### DIFF
--- a/setup_node_exporter.sh
+++ b/setup_node_exporter.sh
@@ -24,7 +24,7 @@ After=network-online.target
 [Service]
 User=$(whoami)
 Restart=on-failure
-ExecStart=$NEXP_DIR/node_exporter --web.listen-address="$CNODE_IP:$NEXP_PORT"
+ExecStart=$NEXP_DIR/node_exporter --collector.systemd --web.listen-address="$CNODE_IP:$NEXP_PORT"
 WorkingDirectory=$NEXP_DIR
 LimitNOFILE=3500
 [Install]


### PR DESCRIPTION
This flag enables use for node_systemd_unit_state

A useful tool for grafana monitoring.

Allows users to monitor services, like cnode.service

Additionally, used in IOHK's example Grafana dashboard.

Without the flag, there will be no data.

Already accepted in guild-operators

https://github.com/cardano-community/guild-operators/pull/930